### PR TITLE
Update docs after successfully witnessing speculative plans and VCS-driven workflows

### DIFF
--- a/abacus/genesis/README.md
+++ b/abacus/genesis/README.md
@@ -97,6 +97,7 @@ We'll perform the following steps in order.
     * Terraform code can be trivial in this stage. No need to control any AWS resources.
     * [PR's should be blocked if the Terraform code is bad.][9]
     * Merges to the main branch should trigger a deployment with required human approval.
+    * [There's a small line in the docs saying that the first run in a fresh workspace must be manual.][10]
 - [ ] Terraform must have access to AWS.
     * [We'll probably set up OIDC between AWS and Terraform.][8]
 - [ ] Terraform should import the AWS organization.
@@ -110,3 +111,4 @@ We'll perform the following steps in order.
 [7]: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
 [8]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration
 [9]: https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests
+[10]: https://developer.hashicorp.com/terraform/cloud-docs/run/ui#manually-starting-runs

--- a/abacus/genesis/README.md
+++ b/abacus/genesis/README.md
@@ -93,7 +93,7 @@ The only requirements we need to start out are the following.
 We'll perform the following steps in order.
 
 - [x] AWS organization and root account are set up.
-- [ ] VCS-driven workflow is set up for HCP Terraform to make deployments and preview changes.
+- [x] VCS-driven workflow is set up for HCP Terraform to make deployments and preview changes.
     * Terraform code can be trivial in this stage. No need to control any AWS resources.
     * [PR's should be blocked if the Terraform code is bad.][9]
     * Merges to the main branch should trigger a deployment with required human approval.
@@ -109,6 +109,6 @@ We'll perform the following steps in order.
 [5]: https://www.terraform.io/
 [6]: https://developer.hashicorp.com/terraform/tutorials/cloud-get-started/cloud-vcs-change
 [7]: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
-[8]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration
+[8]: https://developer.hashicorp.com/terraform/enterprise/workspaces/dynamic-provider-credentials/aws-configuration
 [9]: https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests
 [10]: https://developer.hashicorp.com/terraform/cloud-docs/run/ui#manually-starting-runs

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -32,6 +32,7 @@ import {
   id = "339712758060"
 }
 
+# This is the root account for the org.
 resource "aws_organizations_account" "abacus_org" {
   name      = "abacus-org"
   email     = "the.abacus.app@gmail.com"


### PR DESCRIPTION
This PR has no behavioral change. It only updates markdown files.

However, this PR shows an important milestone. I've accomplished the following.
* Speculative HCP Terraform plans
    * Every PR now runs a dry run plan before merging to test changes.
* VCS-driven deployments.
    * Every merge to the main branch will now trigger a Terraform deployment.
    * I needed to manually trigger one deployment before this could happen automatically.

The Terraform deployments fail because of missing auth. I will implement that next.