### PR TITLE
Migrate to Terraform Cloud deployments

### DIFF
--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -2,24 +2,22 @@ locals {
   the_abacus_app_email              = "the.abacus.app@gmail.com"
   terraform_cloud_aws_oidc_audience = "terraform-cloud.aws-workload-identity"
   terraform_cloud_hostname          = "app.terraform.io"
-  # TODO replace these with terraform.cloud.* references when we re-add the cloud block below.
-  terraform_cloud_organization = "abacus_org"
-  terraform_cloud_project      = "default_project"
-  terraform_cloud_workspace    = "genesis"
+  terraform_cloud_organization      = "abacus_org"
+  terraform_cloud_project           = "default_project"
+  terraform_cloud_workspace         = "genesis"
 }
 
 terraform {
   # At time of writing, we simply use the latest version of Terraform available on HCP Terraform.
   required_version = ">= 1.9.7"
-  # TODO Add this back in when AWS auth is set up.
   # https://developer.hashicorp.com/terraform/language/terraform#terraform-cloud
-  # cloud {
-  #   organization = "abacus_org"
-  #   workspaces {
-  #     name    = "genesis"
-  #     project = "default_project"
-  #   }
-  # }
+  cloud {
+    organization = "abacus_org"
+    workspaces {
+      name    = "genesis"
+      project = "default_project"
+    }
+  }
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/abacus/genesis/terraform-cloud-setup.tf
+++ b/abacus/genesis/terraform-cloud-setup.tf
@@ -60,13 +60,27 @@ resource "tfe_variable" "terraform_cloud_enable_aws_provider_auth" {
 
 }
 
+moved {
+  from = tfe_variable.tfc_aws_role_arn
+  to   = tfe_variable.terraform_cloud_aws_role_arn
+}
+
 # Required for authentication to AWS
 # https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration#required-environment-variables
-resource "tfe_variable" "tfc_aws_role_arn" {
+resource "tfe_variable" "terraform_cloud_aws_role_arn" {
   description  = "The AWS role arn runs will use to authenticate."
   workspace_id = tfe_workspace.terraform_cloud_genesis_workspace.id
 
   key      = "TFC_AWS_RUN_ROLE_ARN"
   value    = aws_iam_role.terraform_cloud_role.arn
+  category = "env"
+}
+
+resource "tfe_variable" "terraform_cloud_tfc_aws_audience" {
+  description  = "The value to use as the audience claim in run identity tokens"
+  workspace_id = tfe_workspace.terraform_cloud_genesis_workspace.id
+
+  key      = "TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE"
+  value    = local.terraform_cloud_aws_oidc_audience
   category = "env"
 }


### PR DESCRIPTION
As promised in https://github.com/josalvatorre/monorepo-alpha/pull/8, this PR finally migrates us from local CLI deployments to Terraform Cloud. It's mostly as simple as adding the `terraform.cloud` block. However, I also had to retroactively add the `TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE` environment variable to get past auth issues. Besides adding that here, I also had to add it manually in the HCP Terraform UI.