### PR TITLE
Specify the hostname in tfe provider

### DIFF
--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -34,11 +34,15 @@ terraform {
   }
 }
 
-provider "tfe" {}
-provider "tls" {}
 provider "aws" {
   region = "us-west-1"
 }
+
+provider "tfe" {
+  hostname = local.terraform_cloud_hostname
+}
+
+provider "tls" {}
 
 import {
   to = aws_organizations_organization.org


### PR DESCRIPTION
I'm facing a weird issue where Terraform Cloud can't find or import the default project. I'm not sure this will fix it, but I should've done it originally. [The tutorial had it set.][1]

[1]: https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/blob/5308cd970c0832f2180d7eb1e645dea33c4e344c/aws/tfc-workspace.tf#L5C1-L5C30