### PR TITLE
Do not use the default project for Terraform Cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 .env
 .env.leave
+.terraform.lock.hcl
 .terraform/
 bazel-*
 blobs/
 manifest.json
-venv/
 terraform.tfstate
 terraform.tfstate.backup
+venv/

--- a/abacus/genesis/aws-iam-auth-for-terraform-cloud.tf
+++ b/abacus/genesis/aws-iam-auth-for-terraform-cloud.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role" "terraform_cloud_role" {
             "${local.terraform_cloud_hostname}:aud" : one(aws_iam_openid_connect_provider.terraform_iam_openid_provider.client_id_list)
           },
           "StringLike" : {
-            "${local.terraform_cloud_hostname}:sub" : "organization:${local.terraform_cloud_organization}:project:${local.terraform_cloud_project}:workspace:${local.terraform_cloud_workspace}:run_phase:*"
+            "${local.terraform_cloud_hostname}:sub" : "organization:${local.terraform_cloud_organization}:project:${terraform.cloud.workspaces.project}:workspace:${local.terraform_cloud_workspace}:run_phase:*"
           }
         }
       }

--- a/abacus/genesis/aws-iam-auth-for-terraform-cloud.tf
+++ b/abacus/genesis/aws-iam-auth-for-terraform-cloud.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role" "terraform_cloud_role" {
             "${local.terraform_cloud_hostname}:aud" : one(aws_iam_openid_connect_provider.terraform_iam_openid_provider.client_id_list)
           },
           "StringLike" : {
-            "${local.terraform_cloud_hostname}:sub" : "organization:${local.terraform_cloud_organization}:project:${terraform.cloud.workspaces.project}:workspace:${local.terraform_cloud_workspace}:run_phase:*"
+            "${local.terraform_cloud_hostname}:sub" : "organization:${tfe_organization.terraform_cloud_organization.name}:project:${tfe_project.terraform_cloud_project.name}:workspace:${tfe_workspace.terraform_cloud_genesis_workspace.name}:run_phase:*"
           }
         }
       }

--- a/abacus/genesis/aws-iam-auth-for-terraform-cloud.tf
+++ b/abacus/genesis/aws-iam-auth-for-terraform-cloud.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role" "terraform_cloud_role" {
             "${local.terraform_cloud_hostname}:aud" : one(aws_iam_openid_connect_provider.terraform_iam_openid_provider.client_id_list)
           },
           "StringLike" : {
-            "${local.terraform_cloud_hostname}:sub" : "organization:${tfe_organization.terraform_cloud_organization.name}:project:${tfe_project.terraform_cloud_project.name}:workspace:${tfe_workspace.terraform_cloud_genesis_workspace.name}:run_phase:*"
+            "${local.terraform_cloud_hostname}:sub" : "organization:${tfe_organization.abacus_org.name}:project:${tfe_project.genesis_default_project.name}:workspace:${tfe_workspace.terraform_cloud_genesis_workspace.name}:run_phase:*"
           }
         }
       }

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -2,7 +2,6 @@ locals {
   terraform_cloud_aws_oidc_audience = "terraform-cloud.aws-workload-identity"
   terraform_cloud_hostname          = "app.terraform.io"
   terraform_cloud_organization      = "abacus_org"
-  terraform_cloud_project           = "default_project"
   terraform_cloud_workspace         = "genesis"
   the_abacus_app_email              = "the.abacus.app@gmail.com"
 }
@@ -15,7 +14,9 @@ terraform {
     organization = "abacus_org"
     workspaces {
       name    = "genesis"
-      project = "default_project"
+      # We wanted to use the default project, but Terraform Cloud failed to recognize it during deployments.
+      # It looks like a bug in Terraform Cloud.
+      project = "genesis_default_project"
     }
   }
   required_providers {

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -2,8 +2,6 @@ locals {
   terraform_cloud_aws_oidc_audience = "terraform-cloud.aws-workload-identity"
   terraform_cloud_hostname          = "app.terraform.io"
   terraform_cloud_organization      = "abacus_org"
-  terraform_cloud_project           = "genesis_default_project"
-  terraform_cloud_workspace         = "genesis"
   the_abacus_app_email              = "the.abacus.app@gmail.com"
 }
 

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -2,6 +2,7 @@ locals {
   terraform_cloud_aws_oidc_audience = "terraform-cloud.aws-workload-identity"
   terraform_cloud_hostname          = "app.terraform.io"
   terraform_cloud_organization      = "abacus_org"
+  terraform_cloud_project           = "genesis_default_project"
   terraform_cloud_workspace         = "genesis"
   the_abacus_app_email              = "the.abacus.app@gmail.com"
 }

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -13,7 +13,7 @@ terraform {
   cloud {
     organization = "abacus_org"
     workspaces {
-      name    = "genesis"
+      name = "genesis"
       # We wanted to use the default project, but Terraform Cloud failed to recognize it during deployments.
       # It looks like a bug in Terraform Cloud.
       project = "genesis_default_project"

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -9,7 +9,7 @@ locals {
 
 terraform {
   # At time of writing, we simply use the latest version of Terraform available on HCP Terraform.
-  required_version = ">= 1.9.7"
+  required_version = ">= 1.9.8"
   # https://developer.hashicorp.com/terraform/language/terraform#terraform-cloud
   cloud {
     organization = "abacus_org"
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.71.0"
+      version = "5.74.0"
     }
     tfe = {
       source  = "hashicorp/tfe"

--- a/abacus/genesis/terraform-cloud.tf
+++ b/abacus/genesis/terraform-cloud.tf
@@ -16,13 +16,8 @@ resource "tfe_organization" "terraform_cloud_organization" {
   email = local.the_abacus_app_email
 }
 
-import {
-  to = tfe_project.terraform_cloud_project
-  id = "prj-ZCQTonyQt6mn3qQr"
-}
-
 resource "tfe_project" "terraform_cloud_project" {
-  name         = local.terraform_cloud_project
+  name         = terraform.cloud.workspaces.project
   organization = tfe_organization.terraform_cloud_organization.name
 }
 
@@ -35,8 +30,8 @@ import {
 # to AWS with the permissions set in the AWS policy.
 # https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace
 resource "tfe_workspace" "terraform_cloud_genesis_workspace" {
-  name                  = local.terraform_cloud_workspace
-  organization          = local.terraform_cloud_organization
+  name                  = terraform.cloud.workspaces.name
+  organization          = terraform.cloud.organization
   project_id            = tfe_project.terraform_cloud_project.id
   working_directory     = "abacus/genesis"
   file_triggers_enabled = false

--- a/abacus/genesis/terraform-cloud.tf
+++ b/abacus/genesis/terraform-cloud.tf
@@ -30,7 +30,7 @@ import {
 # to AWS with the permissions set in the AWS policy.
 # https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace
 resource "tfe_workspace" "terraform_cloud_genesis_workspace" {
-  name                  = local.terraform_cloud_workspace
+  name                  = "genesis"
   organization          = terraform_cloud_organization.name
   project_id            = tfe_project.terraform_cloud_project.id
   working_directory     = "abacus/genesis"

--- a/abacus/genesis/terraform-cloud.tf
+++ b/abacus/genesis/terraform-cloud.tf
@@ -31,7 +31,7 @@ import {
 # https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace
 resource "tfe_workspace" "terraform_cloud_genesis_workspace" {
   name                  = "genesis"
-  organization          = terraform_cloud_organization.name
+  organization          = tfe_organization.terraform_cloud_organization.name
   project_id            = tfe_project.terraform_cloud_project.id
   working_directory     = "abacus/genesis"
   file_triggers_enabled = false

--- a/abacus/genesis/terraform-cloud.tf
+++ b/abacus/genesis/terraform-cloud.tf
@@ -17,7 +17,7 @@ resource "tfe_organization" "terraform_cloud_organization" {
 }
 
 resource "tfe_project" "terraform_cloud_project" {
-  name         = terraform.cloud.workspaces.project
+  name         = "genesis_default_project"
   organization = tfe_organization.terraform_cloud_organization.name
 }
 
@@ -30,8 +30,8 @@ import {
 # to AWS with the permissions set in the AWS policy.
 # https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace
 resource "tfe_workspace" "terraform_cloud_genesis_workspace" {
-  name                  = terraform.cloud.workspaces.name
-  organization          = terraform.cloud.organization
+  name                  = local.terraform_cloud_workspace
+  organization          = terraform_cloud_organization.name
   project_id            = tfe_project.terraform_cloud_project.id
   working_directory     = "abacus/genesis"
   file_triggers_enabled = false

--- a/abacus/genesis/terraform-cloud.tf
+++ b/abacus/genesis/terraform-cloud.tf
@@ -11,14 +11,14 @@ import {
   id = local.terraform_cloud_organization
 }
 
-resource "tfe_organization" "terraform_cloud_organization" {
+resource "tfe_organization" "abacus_org" {
   name  = local.terraform_cloud_organization
   email = local.the_abacus_app_email
 }
 
-resource "tfe_project" "terraform_cloud_project" {
+resource "tfe_project" "genesis_default_project" {
   name         = "genesis_default_project"
-  organization = tfe_organization.terraform_cloud_organization.name
+  organization = tfe_organization.abacus_org.name
 }
 
 import {
@@ -31,8 +31,8 @@ import {
 # https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace
 resource "tfe_workspace" "terraform_cloud_genesis_workspace" {
   name                  = "genesis"
-  organization          = tfe_organization.terraform_cloud_organization.name
-  project_id            = tfe_project.terraform_cloud_project.id
+  organization          = tfe_organization.abacus_org.name
+  project_id            = tfe_project.genesis_default_project.id
   working_directory     = "abacus/genesis"
   file_triggers_enabled = false
   description           = "See description at https://github.com/josalvatorre/monorepo-alpha/tree/f41243576d015278683fa2d41b9f9a086e9a09fc/abacus/genesis"


### PR DESCRIPTION
For reasons I don't understand, Terraform passes on the speculative plan but fails during application because it thinks the default project doesn't exist.

This PR tries to work around this by using another project.