### PR TITLE
Use default project again and add TFE_TOKEN as a variable

### DIFF
--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -13,9 +13,7 @@ terraform {
     organization = "abacus_org"
     workspaces {
       name = "genesis"
-      # We wanted to use the default project, but Terraform Cloud failed to recognize it during deployments.
-      # It looks like a bug in Terraform Cloud.
-      project = "genesis_default_project"
+      project = "default_project"
     }
   }
   required_providers {

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -2,6 +2,7 @@ locals {
   terraform_cloud_aws_oidc_audience = "terraform-cloud.aws-workload-identity"
   terraform_cloud_hostname          = "app.terraform.io"
   terraform_cloud_organization      = "abacus_org"
+  terraform_team_id                 = "team-mhg9S6Zc3jBZ6Q8G"
   the_abacus_app_email              = "the.abacus.app@gmail.com"
 }
 

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -39,7 +39,7 @@ provider "aws" {
 
 provider "tfe" {
   hostname = local.terraform_cloud_hostname
-  token    = var.tfe_token
+  token    = var.TFE_TOKEN
 }
 
 provider "tls" {}

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -39,6 +39,7 @@ provider "aws" {
 
 provider "tfe" {
   hostname = local.terraform_cloud_hostname
+  token    = var.tfe_token
 }
 
 provider "tls" {}

--- a/abacus/genesis/main.tf
+++ b/abacus/genesis/main.tf
@@ -12,7 +12,7 @@ terraform {
   cloud {
     organization = "abacus_org"
     workspaces {
-      name = "genesis"
+      name    = "genesis"
       project = "default_project"
     }
   }

--- a/abacus/genesis/terraform-cloud.tf
+++ b/abacus/genesis/terraform-cloud.tf
@@ -31,6 +31,16 @@ import {
   id = local.terraform_cloud_organization
 }
 
+import {
+  to = tfe_workspace.genesis_workspace
+  id = "ws-h7P1aXBjgAJQyuBg"
+}
+
+import {
+  to = tfe_team.owners
+  id = "${local.terraform_cloud_organization}/${local.terraform_team_id}"
+}
+
 resource "tfe_organization" "abacus_org" {
   name  = local.terraform_cloud_organization
   email = local.the_abacus_app_email
@@ -41,9 +51,9 @@ resource "tfe_project" "genesis_default_project" {
   organization = tfe_organization.abacus_org.name
 }
 
-import {
-  to = tfe_workspace.genesis_workspace
-  id = "ws-h7P1aXBjgAJQyuBg"
+resource "tfe_team" "owners" {
+  name         = "owners"
+  organization = tfe_organization.abacus_org.name
 }
 
 # Runs in this workspace will be automatically authenticated

--- a/abacus/genesis/terraform-cloud.tf
+++ b/abacus/genesis/terraform-cloud.tf
@@ -37,7 +37,7 @@ resource "tfe_organization" "abacus_org" {
 }
 
 resource "tfe_project" "genesis_default_project" {
-  name         = "genesis_default_project"
+  name         = "default_project"
   organization = tfe_organization.abacus_org.name
 }
 

--- a/abacus/genesis/variables.tf
+++ b/abacus/genesis/variables.tf
@@ -1,6 +1,6 @@
 # At time of writing, there's no easy way to create an auto-rotating Terraform Enterprise API token.
 # We'll have to constantly mint new ones.
-variable "tfe_token" {
+variable "TFE_TOKEN" {
   type        = string
   sensitive   = true
   description = <<-EOT
@@ -9,7 +9,7 @@ variable "tfe_token" {
   EOT
 
   validation {
-    condition     = length(var.tfe_token) > 0
+    condition     = length(var.TFE_TOKEN) > 0
     error_message = "TFE_TOKEN must be set. Please provide a valid Terraform Enterprise API token."
   }
 }

--- a/abacus/genesis/variables.tf
+++ b/abacus/genesis/variables.tf
@@ -1,0 +1,15 @@
+# At time of writing, there's no easy way to create an auto-rotating Terraform Enterprise API token.
+# We'll have to constantly mint new ones.
+variable "tfe_token" {
+  type        = string
+  sensitive   = true
+  description = <<-EOT
+  Terraform Enterprise API token. If it becomes expired, you'll need to create a new one.
+  https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens"
+  EOT
+
+  validation {
+    condition     = length(var.tfe_token) > 0
+    error_message = "TFE_TOKEN must be set. Please provide a valid Terraform Enterprise API token."
+  }
+}


### PR DESCRIPTION
## Changes

Based on my research, the likely cause of our missing project problem is that we haven't provided a `TFE_TOKEN`. This is weird, given that we're running these on Terraform Cloud. It's also weird that Terraform doesn't have a simple way to set up auto-rotating tokens.

This PR adds `TFE_TOKEN` as a required variable. The operator will need to mint short-lived tokens for every deployment 😭 Thankfully, Terraform deployments shouldn't be as common as others, so I hope I don't need to automate this.

This PR also changes the project to the default project again. I only tried the alternative project as a failed attempt to get around the missing project issue.

## Resources

* https://registry.terraform.io/providers/hashicorp/tfe/latest/docs#authentication
* https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens
* https://github.com/hashicorp/terraform-provider-tfe/issues/882
* https://support.hashicorp.com/hc/en-us/articles/30556582962707-HCP-Terraform-Resolving-Resource-Not-Found-Error-When-Using-TFE-Provider-in-Terraform-Cloud

### Misleading rotation snippet

You might find snippets in the resources above mentioning rotation. However, I found these to be misleading. At the time of writing, there's no way to create an auto-rotating token for Terraform Cloud. You could *simulate* this by setting up an expiration lifecycle much slower than your deployment rate. For example, if you deploy every few minutes and set each token to expire every hour, then Terraform would be able to replace the token. However, I don't deploy often enough for this to make sense. I would need to set the expiration date to be a long time. It's better to bite the bullet and have a convention around always minting tokens per deployment.